### PR TITLE
Fix ruff lint violations

### DIFF
--- a/src/frogmouth/app/app.py
+++ b/src/frogmouth/app/app.py
@@ -40,7 +40,7 @@ class MarkdownViewer(App[None]):
         Args:
             url: The URL to visit.
         """
-        open_url(url)
+        self.call_from_executor(open_url, url)
 
 
 def get_args() -> Namespace:

--- a/src/frogmouth/data/bookmarks.py
+++ b/src/frogmouth/data/bookmarks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from json import JSONEncoder, dumps, loads
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 from httpx import URL
 
@@ -35,7 +35,7 @@ def bookmarks_file() -> Path:
 class BookmarkEncoder(JSONEncoder):
     """JSON encoder for the bookmark data."""
 
-    def default(self, o: object) -> Any:
+    def default(self, o: object) -> object:
         """Handle the Path and URL values.
 
         Args:
@@ -44,7 +44,9 @@ class BookmarkEncoder(JSONEncoder):
         Return:
             The encoded object.
         """
-        return str(o) if isinstance(o, (Path, URL)) else o
+        if isinstance(o, (Path, URL)):
+            return str(o)
+        return super().default(o)
 
 
 def save_bookmarks(bookmarks: list[Bookmark]) -> None:

--- a/src/frogmouth/data/history.py
+++ b/src/frogmouth/data/history.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from json import JSONEncoder, dumps, loads
 from pathlib import Path
-from typing import Any
 
 from httpx import URL
 
@@ -26,7 +25,7 @@ def history_file() -> Path:
 class HistoryEncoder(JSONEncoder):
     """JSON encoder for the history data."""
 
-    def default(self, o: object) -> Any:
+    def default(self, o: object) -> object:
         """Handle the Path and URL values.
 
         Args:
@@ -35,7 +34,9 @@ class HistoryEncoder(JSONEncoder):
         Return:
             The encoded object.
         """
-        return str(o) if isinstance(o, (Path, URL)) else o
+        if isinstance(o, (Path, URL)):
+            return str(o)
+        return super().default(o)
 
 
 def save_history(history: list[Path | URL]) -> None:

--- a/src/frogmouth/dialogs/input_dialog.py
+++ b/src/frogmouth/dialogs/input_dialog.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from textual import on
 from textual.binding import Binding
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class InputDialog(ModalScreen[str]):
     """A modal dialog for getting a single input from the user."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS: ClassVar[str] = """
     InputDialog {
         align: center middle;
     }
@@ -55,7 +55,7 @@ class InputDialog(ModalScreen[str]):
     """
     """The default styling for the input dialog."""
 
-    BINDINGS = [
+    BINDINGS: ClassVar[list[Binding]] = [
         Binding("escape", "app.pop_screen", "", show=False),
     ]
     """Bindings for the dialog."""

--- a/src/frogmouth/dialogs/text_dialog.py
+++ b/src/frogmouth/dialogs/text_dialog.py
@@ -1,18 +1,24 @@
 """Provides a base modal dialog for showing text to the user."""
 
-from rich.text import TextType
-from textual.app import ComposeResult
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
 from textual.binding import Binding
 from textual.containers import Center, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Static
-from textual.widgets._button import ButtonVariant
+
+if TYPE_CHECKING:
+    from rich.text import TextType
+    from textual.app import ComposeResult
+    from textual.widgets._button import ButtonVariant
 
 
 class TextDialog(ModalScreen[None]):
     """Base modal dialog for showing information."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS: ClassVar[str] = """
     TextDialog {
         align: center middle;
     }
@@ -43,7 +49,7 @@ class TextDialog(ModalScreen[None]):
     """
     """Default CSS for the base text modal dialog."""
 
-    BINDINGS = [
+    BINDINGS: ClassVar[list[Binding]] = [
         Binding("escape", "dismiss(None)", "", show=False),
     ]
     """Bindings for the base text modal dialog."""

--- a/src/frogmouth/dialogs/yes_no_dialog.py
+++ b/src/frogmouth/dialogs/yes_no_dialog.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from textual.binding import Binding
 from textual.containers import Center, Horizontal, Vertical
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class YesNoDialog(ModalScreen[bool]):
     """A dialog for asking a user a yes/no question."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS: ClassVar[str] = """
     YesNoDialog {
         align: center middle;
     }
@@ -59,7 +59,7 @@ class YesNoDialog(ModalScreen[bool]):
     """
     """The default CSS for the yes/no dialog."""
 
-    BINDINGS = [
+    BINDINGS: ClassVar[list[Binding]] = [
         Binding("left,up", "focus_previous", "", show=False),
         Binding("right,down", "focus_next", "", show=False),
         Binding("escape", "app.pop_screen", "", show=False),
@@ -72,6 +72,7 @@ class YesNoDialog(ModalScreen[bool]):
         question: str,
         yes_label: str = "Yes",
         no_label: str = "No",
+        *,
         yes_first: bool = True,
     ) -> None:
         """Initialise the yes/no dialog.

--- a/src/frogmouth/utility/type_tests.py
+++ b/src/frogmouth/utility/type_tests.py
@@ -2,7 +2,6 @@
 
 from functools import singledispatch
 from pathlib import Path
-from typing import Any
 
 from httpx import URL
 
@@ -10,8 +9,8 @@ from frogmouth.data.config import load_config
 
 
 @singledispatch
-def maybe_markdown(resource: Any) -> bool:
-    """Does the given resource look like it's a Markdown file?
+def maybe_markdown(resource: object) -> bool:
+    """Determine whether the given resource looks like a Markdown file.
 
     Args:
         resource: The resource to test.
@@ -40,7 +39,7 @@ def _(resource: URL) -> bool:
 
 
 def is_likely_url(candidate: str) -> bool:
-    """Does the given value look something like a URL?
+    """Determine whether the given value looks like a URL.
 
     Args:
         candidate: The candidate to check.

--- a/src/frogmouth/widgets/navigation.py
+++ b/src/frogmouth/widgets/navigation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from textual.binding import Binding
 from textual.containers import Vertical
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 class Navigation(Vertical, can_focus=False, can_focus_children=True):
     """A navigation panel widget."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS: ClassVar[str] = """
     Navigation {
         width: 44;
         background: $panel;
@@ -49,17 +49,17 @@ class Navigation(Vertical, can_focus=False, can_focus_children=True):
     }
     """
 
-    BINDINGS = [
+    BINDINGS: ClassVar[list[Binding]] = [
         Binding("comma,a,ctrl+left,shift+left,h", "previous_tab", "", show=False),
         Binding("full_stop,d,ctrl+right,shift+right,l", "next_tab", "", show=False),
         Binding("\\", "toggle_dock", "Dock left/right"),
     ]
     """Bindings local to the navigation pane."""
 
-    popped_out: var[bool] = var(False)
+    popped_out: var[bool] = var(default=False)
     """Is the navigation popped out?"""
 
-    docked_left: var[bool] = var(True)
+    docked_left: var[bool] = var(default=True)
     """Should navigation be docked to the left side of the screen?"""
 
     def compose(self) -> ComposeResult:

--- a/src/frogmouth/widgets/navigation_panes/bookmarks.py
+++ b/src/frogmouth/widgets/navigation_panes/bookmarks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from rich.text import Text
 from textual.binding import Binding
@@ -51,7 +51,7 @@ class Entry(Option):
 class Bookmarks(NavigationPane):
     """Bookmarks navigation pane."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS: ClassVar[str] = """
     Bookmarks {
         height: 100%;
     }
@@ -68,7 +68,7 @@ class Bookmarks(NavigationPane):
     """
     """The default CSS for the bookmarks navigation pane."""
 
-    BINDINGS = [
+    BINDINGS: ClassVar[list[Binding]] = [
         Binding("delete", "delete", "Delete the bookmark"),
         Binding("r", "rename", "Rename the bookmark"),
     ]
@@ -132,17 +132,19 @@ class Bookmarks(NavigationPane):
             event: The event to handle.
         """
         event.stop()
-        assert isinstance(event.option, Entry)
-        self.post_message(self.Goto(event.option.bookmark))
+        option = event.option
+        if not isinstance(option, Entry):
+            return
+        self.post_message(self.Goto(option.bookmark))
 
-    def delete_bookmark(self, bookmark: int, delete_it: bool) -> None:
+    def delete_bookmark(self, bookmark: int, *, confirm: bool) -> None:
         """Delete a given bookmark.
 
         Args:
             bookmark: The bookmark to delete.
-            delete_it: Should it be deleted?
+            confirm: Should it be deleted?
         """
-        if delete_it:
+        if confirm:
             del self._bookmarks[bookmark]
             self._bookmarks_updated()
 
@@ -154,7 +156,7 @@ class Bookmarks(NavigationPane):
                     "Delete bookmark",
                     "Are you sure you want to delete the bookmark?",
                 ),
-                partial(self.delete_bookmark, bookmark),
+                lambda decision: self.delete_bookmark(bookmark, confirm=decision),
             )
 
     def rename_bookmark(self, bookmark: int, new_name: str) -> None:

--- a/src/frogmouth/widgets/navigation_panes/navigation_pane.py
+++ b/src/frogmouth/widgets/navigation_panes/navigation_pane.py
@@ -17,7 +17,9 @@ class NavigationPane(TabPane):
         -------
             Self.
         """
-        assert self.parent is not None
+        if self.parent is None:
+            msg = "Navigation pane must have a parent before activation."
+            raise RuntimeError(msg)
         if self.id is not None and isinstance(self.parent.parent, TabbedContent):
             self.parent.parent.active = self.id
         return self

--- a/src/frogmouth/widgets/navigation_panes/table_of_contents.py
+++ b/src/frogmouth/widgets/navigation_panes/table_of_contents.py
@@ -1,5 +1,7 @@
 """Provides the table of contents navigation pane."""
 
+from typing import ClassVar
+
 from textual.app import ComposeResult
 from textual.widgets import Markdown, Tree
 from textual.widgets.markdown import MarkdownTableOfContents
@@ -10,7 +12,7 @@ from .navigation_pane import NavigationPane
 class TableOfContents(NavigationPane):
     """Markdown document table of contents navigation pane."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS: ClassVar[str] = """
     TableOfContents {
         height: 100%;
     }
@@ -26,7 +28,8 @@ class TableOfContents(NavigationPane):
         padding: 0;
     }
 
-    TableOfContents > MarkdownTableOfContents > Tree:focus .tree--cursor, TableOfContents > MarkdownTableOfContents > Tree .tree--cursor {
+    TableOfContents > MarkdownTableOfContents > Tree:focus .tree--cursor,
+        TableOfContents > MarkdownTableOfContents > Tree .tree--cursor {
         background: $accent 50%;
         color: $text;
     }
@@ -35,6 +38,7 @@ class TableOfContents(NavigationPane):
     def __init__(self) -> None:
         """Initialise the table of contents navigation pane."""
         super().__init__("Contents")
+        self._toc: MarkdownTableOfContents | None = None
 
     def set_focus_within(self) -> None:
         """Ensure the tree in the table of contents is focused."""
@@ -52,7 +56,8 @@ class TableOfContents(NavigationPane):
         # and documents. So... we make one and ignore it.
         #
         # https://github.com/Textualize/textual/issues/2516
-        yield MarkdownTableOfContents(Markdown())
+        self._toc = MarkdownTableOfContents(Markdown())
+        yield self._toc
 
     def on_table_of_contents_updated(self, event: Markdown.TableOfContentsUpdated) -> None:
         """Handle a table of contents update event.
@@ -60,4 +65,5 @@ class TableOfContents(NavigationPane):
         Args:
             event: The table of content update event to handle.
         """
-        self.query_one(MarkdownTableOfContents).table_of_contents = event.table_of_contents
+        toc = self._toc or self.query_one(MarkdownTableOfContents)
+        toc.table_of_contents = event.table_of_contents

--- a/src/frogmouth/widgets/viewer.py
+++ b/src/frogmouth/widgets/viewer.py
@@ -119,7 +119,12 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
     ]
     """Bindings for the Markdown viewer widget."""
 
-    history: var[History] = var(History)
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        """Initialise the viewer."""
+        super().__init__(*args, **kwargs)
+        self.history = History()
+
+    history: var[History] = var(default=History())
     """The browsing history."""
 
     viewing_location: var[bool] = var(default=False)


### PR DESCRIPTION
## Summary
- annotate declarative constants with ClassVar and update dialogs to use stored widgets and asynchronous link handling
- tighten data encoders and utility helpers to avoid Any usage while clarifying docstrings
- refactor navigation panes, main screen, and viewer helpers to satisfy ruff boolean and assertion rules and modernize compose usage

## Testing
- .venv/bin/ruff format src/ tests/
- .venv/bin/ruff check src/ tests/
- .venv/bin/ty check src/ tests/
- .venv/bin/pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc4ef6952083278b702c500ad374d6