### PR TITLE
feat: add inline image rendering

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- add inline image rendering in Markdown documents using textual-image.
 - Front matter is now ignored when viewing a file.
   [#15](https://github.com/Textualize/frogmouth/issues/15)
 - Added support for jumping to an internal anchor.

--- a/README.md
+++ b/README.md
@@ -101,15 +101,19 @@ Use <kbd>tab</kbd> and <kbd>shift</kbd>+<kbd>tab</kbd> to navigate between the v
 
 ## Features
 
-You can load README files direct from GitHub repositories with the `gh` command.
-Use the following syntax:
+* Inline image rendering within Markdown documents using
+  [`textual-image`](https://github.com/Textualize/textual-image). Frogmouth falls
+  back to alt text when image rendering isn't available in the current
+  environment.
+* Load README files directly from GitHub repositories with the `gh` command.
+  Use the following syntax:
 
-```
-frogmouth gh textualize/textual
-```
+  ```
+  frogmouth gh textualize/textual
+  ```
 
-This also works with the address bar in the app.
-See the help (<kbd>F1</kbd>) in the app for details.
+  This also works with the address bar in the app.
+  See the help (<kbd>F1</kbd>) in the app for details.
 
 ## Follow this project
 

--- a/src/frogmouth/utility/__init__.py
+++ b/src/frogmouth/utility/__init__.py
@@ -1,12 +1,16 @@
 """General utility and support code."""
 
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from .forge import (
     build_raw_bitbucket_url,
     build_raw_codeberg_url,
     build_raw_github_url,
     build_raw_gitlab_url,
 )
-from .type_tests import is_likely_url, maybe_markdown
 
 __all__ = [
     "build_raw_bitbucket_url",
@@ -16,3 +20,33 @@ __all__ = [
     "is_likely_url",
     "maybe_markdown",
 ]
+
+if TYPE_CHECKING:
+    from .type_tests import is_likely_url as _is_likely_url
+    from .type_tests import maybe_markdown as _maybe_markdown
+
+    is_likely_url = _is_likely_url
+    maybe_markdown = _maybe_markdown
+
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "is_likely_url": ("frogmouth.utility.type_tests", "is_likely_url"),
+    "maybe_markdown": ("frogmouth.utility.type_tests", "maybe_markdown"),
+}
+
+
+def __getattr__(name: str) -> object:
+    """Dynamically resolve lazily imported members."""
+    try:
+        module_name, attr_name = _LAZY_IMPORTS[name]
+    except KeyError as exc:  # pragma: no cover - defensive programming
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg) from exc
+    module = import_module(module_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial proxy
+    return sorted({*globals(), *__all__})

--- a/src/frogmouth/utility/image_loader.py
+++ b/src/frogmouth/utility/image_loader.py
@@ -1,0 +1,96 @@
+"""Helpers to safely import textual-image rendering support."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import logging
+import sys
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterator, TextIO, cast
+
+logger = logging.getLogger(__name__)
+
+
+class _PatchedStream:
+    """Proxy that forces :func:`isatty` to return ``False``."""
+
+    def __init__(self, stream: TextIO) -> None:
+        self._stream = stream
+
+    def __getattr__(self, name: str) -> object:  # pragma: no cover - passthrough
+        return getattr(self._stream, name)
+
+    @staticmethod
+    def isatty() -> bool:
+        return False
+
+
+@contextlib.contextmanager
+def _suppress_terminal_detection() -> Iterator[None]:
+    """Temporarily present streams that appear to be non-TTY objects."""
+    original_stdout = getattr(sys, "__stdout__", None)
+    original_stdin = getattr(sys, "__stdin__", None)
+    try:
+        if original_stdout is not None:
+            sys.__stdout__ = cast("TextIO", _PatchedStream(original_stdout))  # type: ignore[assignment]
+        if original_stdin is not None:
+            sys.__stdin__ = cast("TextIO", _PatchedStream(original_stdin))  # type: ignore[assignment]
+        yield
+    finally:  # pragma: no branch - restoration happens regardless of branch coverage
+        if original_stdout is not None:
+            sys.__stdout__ = original_stdout
+        if original_stdin is not None:
+            sys.__stdin__ = original_stdin
+
+
+def _normalise_mode(renderable: object) -> str:
+    """Create a human readable rendering mode description."""
+    module = getattr(renderable, "__module__", "")
+    if module.endswith("sixel"):
+        return "sixel"
+    if module.endswith("tgp"):
+        return "tgp"
+    if module.endswith("halfcell"):
+        return "halfcell"
+    if module.endswith("unicode"):
+        return "unicode"
+    return "auto"
+
+
+@dataclass(frozen=True)
+class ImageSupport:
+    """Information describing the available image widget."""
+
+    widget: type[object]
+    mode: str
+
+
+@lru_cache(maxsize=1)
+def load_image_support() -> ImageSupport | None:
+    """Attempt to import the ``textual_image`` widget safely.
+
+    Returns
+    -------
+        An :class:`ImageSupport` instance if the dependency is installed and
+        the current environment supports initialisation, otherwise ``None``.
+    """
+    try:
+        with _suppress_terminal_detection():
+            module = importlib.import_module("textual_image.widget")
+    except ModuleNotFoundError:
+        logger.info("textual-image is not installed; disabling inline images")
+        return None
+    except Exception as error:  # noqa: BLE001  # pragma: no cover - defensive fallback
+        logger.warning("Unable to enable inline images", exc_info=error)
+        return None
+
+    image_cls: type[object] = module.Image
+    renderable = getattr(image_cls, "_Renderable", None)
+    mode = _normalise_mode(renderable) if renderable is not None else "auto"
+    logger.debug("Inline images enabled via %s mode", mode)
+    return ImageSupport(widget=image_cls, mode=mode)
+
+
+__all__ = ["ImageSupport", "load_image_support"]

--- a/src/frogmouth/utility/image_resolver.py
+++ b/src/frogmouth/utility/image_resolver.py
@@ -1,0 +1,156 @@
+"""Resolve image references for Markdown documents."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from httpx import URL, AsyncClient, HTTPStatusError, RequestError
+
+from frogmouth.utility.advertising import USER_AGENT
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class ImageLoadResult:
+    """The outcome of resolving an image reference."""
+
+    location: str
+    """A human readable representation of the resolved location."""
+
+    payload: bytes | Path | None
+    """Raw bytes or a filesystem path that the renderer can consume."""
+
+    error: str | None = None
+    """An optional error message when the lookup failed."""
+
+    def as_stream(self) -> io.BytesIO | Path | None:
+        """Return the payload in a form that the image widget understands."""
+        if isinstance(self.payload, Path):
+            return self.payload
+        if isinstance(self.payload, bytes):
+            return io.BytesIO(self.payload)
+        return None
+
+
+class ImageResolver:
+    """Resolve Markdown image sources relative to a document location."""
+
+    def __init__(
+        self,
+        client_factory: Callable[[], AsyncClient] | None = None,
+    ) -> None:
+        self._base_path: Path | None = None
+        self._base_url: URL | None = None
+        self._client_factory = client_factory or self._default_client_factory
+        self._client: AsyncClient | None = None
+        self._cache: dict[str, bytes] = {}
+        self._lock = asyncio.Lock()
+
+    async def aclose(self) -> None:
+        """Close any underlying HTTP client resources."""
+        async with self._lock:
+            if self._client is not None:
+                await self._client.aclose()
+                self._client = None
+
+    def update_location(self, location: Path | URL | None) -> None:
+        """Record the location of the currently viewed document."""
+        if isinstance(location, Path):
+            if location.is_file() or location.suffix:
+                self._base_path = location.parent
+            else:
+                self._base_path = location
+            self._base_url = None
+            logger.debug("Set image resolver base path to %s", self._base_path)
+        elif isinstance(location, URL):
+            self._base_url = location
+            self._base_path = None
+            logger.debug("Set image resolver base URL to %s", self._base_url)
+        else:
+            self._base_path = None
+            self._base_url = None
+            logger.debug("Cleared image resolver base location")
+
+    async def resolve(self, source: str) -> ImageLoadResult:
+        """Resolve an image path to local data."""
+        if not source:
+            return ImageLoadResult(location="", payload=None, error="Empty image source")
+
+        url = self._coerce_url(source)
+        if url is not None:
+            return await self._resolve_remote(url)
+        return await self._resolve_local(source)
+
+    async def _resolve_local(self, source: str) -> ImageLoadResult:
+        candidate = Path(source)
+        if not candidate.is_absolute():
+            base_path = self._base_path or Path.cwd()
+            candidate = (base_path / candidate).expanduser().resolve()
+        logger.debug("Resolving local image %s", candidate)
+        if candidate.exists():
+            return ImageLoadResult(location=str(candidate), payload=candidate)
+        return ImageLoadResult(
+            location=str(candidate),
+            payload=None,
+            error="Image file not found",
+        )
+
+    async def _resolve_remote(self, url: URL) -> ImageLoadResult:
+        key = str(url)
+        if key in self._cache:
+            logger.debug("Using cached remote image %s", key)
+            return ImageLoadResult(location=key, payload=self._cache[key])
+
+        client = await self._ensure_client()
+        try:
+            response = await client.get(url, follow_redirects=True)
+            response.raise_for_status()
+        except HTTPStatusError as error:
+            logger.warning("Remote image %s returned error", url, exc_info=error)
+            return ImageLoadResult(location=key, payload=None, error=str(error))
+        except RequestError as error:
+            logger.warning("Failed to fetch remote image %s", url, exc_info=error)
+            return ImageLoadResult(location=key, payload=None, error=str(error))
+
+        content = bytes(response.content)
+        self._cache[key] = content
+        logger.debug("Fetched remote image %s (%d bytes)", key, len(content))
+        return ImageLoadResult(location=key, payload=content)
+
+    def _coerce_url(self, source: str) -> URL | None:
+        try:
+            direct = URL(source)
+        except ValueError:
+            direct = None
+        else:
+            if direct.scheme in {"http", "https"}:
+                return direct
+            if direct.scheme:
+                return None
+
+        if self._base_url is None:
+            return None
+
+        joined = self._base_url.join(source)
+        if joined.scheme in {"http", "https"}:
+            return joined
+        return None
+
+    async def _ensure_client(self) -> AsyncClient:
+        async with self._lock:
+            if self._client is None:
+                self._client = self._client_factory()
+            return self._client
+
+    @staticmethod
+    def _default_client_factory() -> AsyncClient:
+        return AsyncClient(headers={"user-agent": USER_AGENT})
+
+
+__all__ = ["ImageLoadResult", "ImageResolver"]

--- a/src/frogmouth/widgets/markdown.py
+++ b/src/frogmouth/widgets/markdown.py
@@ -1,0 +1,344 @@
+"""Markdown widget with inline image support."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Callable
+
+from markdown_it import MarkdownIt
+from rich.style import Style
+from rich.text import Text
+from textual.await_complete import AwaitComplete
+from textual.widgets import _markdown as base_markdown  # noqa: PLC2701
+
+from frogmouth.utility.image_loader import ImageSupport, load_image_support
+from frogmouth.utility.image_resolver import ImageResolver
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from httpx import URL
+    from markdown_it.token import Token
+    from textual import events
+
+
+class MarkdownImage(base_markdown.MarkdownBlock):
+    """A block dedicated to rendering an inline image."""
+
+    DEFAULT_CSS = """
+    MarkdownImage {
+        margin: 1 0;
+    }
+
+    MarkdownImage.-link {
+        text-style: underline;
+    }
+    """
+
+    def __init__(
+        self,
+        markdown: ImageMarkdown,
+        source: str,
+        alt_text: str,
+        title: str,
+        style: Style,
+        resolver: ImageResolver,
+        support: ImageSupport | None,
+        link_href: str | None,
+    ) -> None:
+        super().__init__(markdown)
+        self._source = source
+        self._alt_text = alt_text
+        self._title = title
+        self._style = style
+        self._resolver = resolver
+        self._support = support
+        self._link_href = link_href
+        self._load_task: asyncio.Task[None] | None = None
+        self._image_widget = None
+        self._last_error: str | None = None
+        self._show_status(self._initial_caption)
+
+    @property
+    def image_widget(self):
+        """Return the mounted image widget, if any."""
+        return self._image_widget
+
+    @property
+    def error(self) -> str | None:
+        """Return the last error message, if any."""
+        return self._last_error
+
+    @property
+    def support_available(self) -> bool:
+        """Return ``True`` when the textual-image integration is active."""
+        return self._support is not None
+
+    def _show_status(self, message: str | None) -> None:
+        text = Text()
+        if message:
+            text.append(message, self._style)
+        self.set_content(text)
+
+    @property
+    def _initial_caption(self) -> str:
+        return self._alt_text or self._title or self._source
+
+    async def on_mount(self) -> None:
+        if self._support is None:
+            self._last_error = "Inline images require textual-image"
+            self._show_status(f"{self._initial_caption} ({self._last_error})")
+            return
+        self._load_task = asyncio.create_task(self._load())
+
+    async def on_unmount(self) -> None:
+        if self._load_task is not None:
+            self._load_task.cancel()
+            self._load_task = None
+
+    async def on_click(self, event: events.Click) -> None:
+        if self._link_href:
+            event.stop()
+            await self.action_link(self._link_href)
+
+    async def _load(self) -> None:
+        try:
+            result = await self._resolver.resolve(self._source)
+        except asyncio.CancelledError:  # pragma: no cover - cancellation path
+            return
+        except Exception as error:  # noqa: BLE001  # pragma: no cover - defensive fallback
+            self._last_error = str(error)
+            self._show_status(f"{self._initial_caption} ({self._last_error})")
+            return
+        finally:
+            self._load_task = None
+
+        if result.error:
+            self._last_error = result.error
+            caption = f"{self._initial_caption} ({result.error})" if self._initial_caption else result.error
+            self._show_status(caption)
+            return
+
+        payload = result.as_stream()
+        if payload is None:
+            self._last_error = "Unsupported image payload"
+            self._show_status(f"{self._initial_caption} ({self._last_error})")
+            return
+
+        widget_cls = self._support.widget
+        image_widget = widget_cls(payload)
+        self._image_widget = image_widget
+        if self._link_href:
+            self.add_class("-link")
+            image_widget.can_focus = True
+        self._last_error = None
+        caption = self._alt_text or self._title or result.location
+        self._show_status(caption)
+        if result.location:
+            self.tooltip = result.location
+        await self.mount(image_widget)
+
+
+class ImageMarkdownParagraph(base_markdown.MarkdownParagraph):
+    """A paragraph block that is aware of image tokens."""
+
+    def build_from_token(self, token: Token) -> None:  # noqa: C901, PLR0912
+        self._token = token
+        style_stack: list[Style] = [Style()]
+        link_stack: list[str | None] = [None]
+        content = Text()
+        has_non_image_text = False
+        markdown: ImageMarkdown = self._markdown  # type: ignore[assignment]
+
+        def attr_as_str(value: object) -> str:
+            if isinstance(value, str):
+                return value
+            if value is None:
+                return ""
+            return str(value)
+
+        for child in token.children or ():
+            child_type = child.type
+            if child_type == "text":
+                content.append(child.content, style_stack[-1])
+                has_non_image_text = True
+            elif child_type == "hardbreak":
+                content.append("\n")
+                has_non_image_text = True
+            elif child_type == "softbreak":
+                content.append(" ", style_stack[-1])
+                has_non_image_text = True
+            elif child_type == "code_inline":
+                content.append(
+                    child.content,
+                    style_stack[-1] + markdown.get_component_rich_style("code_inline", partial=True),
+                )
+                has_non_image_text = True
+            elif child_type == "em_open":
+                style_stack.append(
+                    style_stack[-1] + markdown.get_component_rich_style("em", partial=True),
+                )
+            elif child_type == "strong_open":
+                style_stack.append(
+                    style_stack[-1] + markdown.get_component_rich_style("strong", partial=True),
+                )
+            elif child_type == "s_open":
+                style_stack.append(
+                    style_stack[-1] + markdown.get_component_rich_style("s", partial=True),
+                )
+            elif child_type == "link_open":
+                href = child.attrs.get("href", "")
+                action = f"link({href!r})"
+                style_stack.append(style_stack[-1] + Style.from_meta({"@click": action}))
+                link_stack.append(href)
+            elif child_type == "image":
+                block = MarkdownImage(
+                    markdown=markdown,
+                    source=attr_as_str(child.attrs.get("src", "")),
+                    alt_text=attr_as_str(child.attrs.get("alt", "")),
+                    title=attr_as_str(child.attrs.get("title", "")),
+                    style=style_stack[-1],
+                    resolver=markdown.image_resolver,
+                    support=markdown.image_support,
+                    link_href=link_stack[-1],
+                )
+                self._blocks.append(block)
+                if has_non_image_text:
+                    caption = child.attrs.get("alt") or child.attrs.get("src") or "image"
+                    content.append(f" [{caption}]", style_stack[-1])
+            elif child_type == "link_close":
+                style_stack.pop()
+                link_stack.pop()
+            elif child_type.endswith("_close"):
+                style_stack.pop()
+            elif child.content:
+                content.append(child.content, style_stack[-1])
+                has_non_image_text = True
+
+        if not has_non_image_text and self._blocks:
+            content = Text()
+        self.set_content(content)
+
+
+class ImageMarkdown(base_markdown.Markdown):
+    """Drop-in replacement for Textual's Markdown widget with image support."""
+
+    def __init__(
+        self,
+        markdown: str | None = None,
+        *,
+        name: str | None = None,
+        id: str | None = None,  # noqa: A002 - match Textual signature
+        classes: str | None = None,
+        parser_factory: Callable[[], MarkdownIt] | None = None,
+        resolver: ImageResolver | None = None,
+        support: ImageSupport | None = None,
+    ) -> None:
+        super().__init__(
+            markdown,
+            name=name,
+            id=id,
+            classes=classes,
+            parser_factory=parser_factory,
+        )
+        self._image_resolver = resolver or ImageResolver()
+        self._image_support = support if support is not None else load_image_support()
+
+    @property
+    def image_support(self) -> ImageSupport | None:
+        return self._image_support
+
+    @property
+    def image_resolver(self) -> ImageResolver:
+        return self._image_resolver
+
+    def set_resource_location(self, location: Path | URL | None) -> None:
+        self._image_resolver.update_location(location)
+
+    async def load(self, path: Path) -> None:
+        self.set_resource_location(path)
+        await super().load(path)
+
+    def update(self, markdown: str) -> AwaitComplete:  # noqa: C901, PLR0912, PLR0915
+        output: list[base_markdown.MarkdownBlock] = []
+        stack: list[base_markdown.MarkdownBlock] = []
+        parser = MarkdownIt("gfm-like") if self._parser_factory is None else self._parser_factory()
+
+        block_id: int = 0
+        self._table_of_contents = []
+
+        for token in parser.parse(markdown):
+            if token.type == "heading_open":
+                block_id += 1
+                stack.append(base_markdown.HEADINGS[token.tag](self, id=f"block{block_id}"))
+            elif token.type == "hr":
+                output.append(base_markdown.MarkdownHorizontalRule(self))
+            elif token.type == "paragraph_open":
+                stack.append(ImageMarkdownParagraph(self))
+            elif token.type == "blockquote_open":
+                stack.append(base_markdown.MarkdownBlockQuote(self))
+            elif token.type == "bullet_list_open":
+                stack.append(base_markdown.MarkdownBulletList(self))
+            elif token.type == "ordered_list_open":
+                stack.append(base_markdown.MarkdownOrderedList(self))
+            elif token.type == "list_item_open":
+                if token.info:
+                    stack.append(base_markdown.MarkdownOrderedListItem(self, token.info))
+                else:
+                    item_count = sum(
+                        1 for block in stack if isinstance(block, base_markdown.MarkdownUnorderedListItem)
+                    )
+                    stack.append(
+                        base_markdown.MarkdownUnorderedListItem(
+                            self,
+                            self.BULLETS[item_count % len(self.BULLETS)],
+                        )
+                    )
+            elif token.type == "table_open":
+                stack.append(base_markdown.MarkdownTable(self))
+            elif token.type == "tbody_open":
+                stack.append(base_markdown.MarkdownTBody(self))
+            elif token.type == "thead_open":
+                stack.append(base_markdown.MarkdownTHead(self))
+            elif token.type == "tr_open":
+                stack.append(base_markdown.MarkdownTR(self))
+            elif token.type == "th_open":
+                stack.append(base_markdown.MarkdownTH(self))
+            elif token.type == "td_open":
+                stack.append(base_markdown.MarkdownTD(self))
+            elif token.type.endswith("_close"):
+                block = stack.pop()
+                if token.type == "heading_close":
+                    heading = block._text.plain  # noqa: SLF001
+                    level = int(token.tag[1:])
+                    self._table_of_contents.append((level, heading, block.id))
+                if stack:
+                    stack[-1]._blocks.append(block)  # noqa: SLF001
+                else:
+                    output.append(block)
+            elif token.type == "inline":
+                stack[-1].build_from_token(token)
+            elif token.type in {"fence", "code_block"}:
+                (stack[-1]._blocks if stack else output).append(  # noqa: SLF001
+                    base_markdown.MarkdownFence(self, token.content.rstrip(), token.info)
+                )
+            else:
+                external = self.unhandled_token(token)
+                if external is not None:
+                    (stack[-1]._blocks if stack else output).append(external)  # noqa: SLF001
+
+        self.post_message(
+            base_markdown.Markdown.TableOfContentsUpdated(self, self._table_of_contents).set_sender(self)
+        )
+        markdown_block = self.query("MarkdownBlock")
+
+        async def await_update() -> None:
+            """Update in a single batch."""
+            with self.app.batch_update():
+                await markdown_block.remove()
+                await self.mount_all(output)
+
+        return AwaitComplete(await_update())
+
+
+__all__ = ["ImageMarkdown", "ImageMarkdownParagraph", "MarkdownImage"]

--- a/src/frogmouth/widgets/viewer.py
+++ b/src/frogmouth/widgets/viewer.py
@@ -15,11 +15,11 @@ from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.message import Message
 from textual.reactive import var
-from textual.widgets import Markdown
 
 from frogmouth import __version__
 from frogmouth.dialogs import ErrorDialog
 from frogmouth.utility.advertising import APPLICATION_TITLE, USER_AGENT
+from frogmouth.widgets.markdown import ImageMarkdown
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
@@ -152,15 +152,15 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
     @staticmethod
     def compose() -> ComposeResult:
         """Compose the markdown viewer."""
-        yield Markdown(
+        yield ImageMarkdown(
             PLACEHOLDER,
             parser_factory=lambda: MarkdownIt("gfm-like").use(front_matter.front_matter_plugin),
         )
 
     @property
-    def document(self) -> Markdown:
+    def document(self) -> ImageMarkdown:
         """The markdown document."""
-        return self.query_one(Markdown)
+        return self.query_one(ImageMarkdown)
 
     @property
     def location(self) -> Path | URL | None:
@@ -250,6 +250,7 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
         if any(
             content_type.startswith(f"text/{sub_type}") for sub_type in ("plain", "markdown", "x-markdown")
         ):
+            self.document.set_resource_location(location)
             self.document.update(response.text)
             self._post_load(location, remember)
         else:
@@ -286,6 +287,7 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
             content: The text to show.
         """
         self.viewing_location = False
+        self.document.set_resource_location(None)
         self.document.update(content)
         self.scroll_home(animate=False)
 

--- a/tests/test_markdown_images.py
+++ b/tests/test_markdown_images.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from httpx import URL, AsyncClient, MockTransport, Request, Response
+from textual.app import App
+
+from frogmouth.utility.image_loader import load_image_support
+from frogmouth.utility.image_resolver import ImageResolver
+from frogmouth.widgets.markdown import ImageMarkdown, MarkdownImage
+
+if TYPE_CHECKING:
+    import pytest
+
+TEST_IMAGE = Path("tests/data/gracehopper.jpg")
+
+
+class _MarkdownApp(App[None]):
+    def __init__(self, widget: ImageMarkdown) -> None:
+        super().__init__()
+        self._widget = widget
+
+    def compose(self):  # type: ignore[override]
+        yield self._widget
+
+
+def test_local_image_mounts_widget(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        image_path = tmp_path / TEST_IMAGE.name
+        image_path.write_bytes(TEST_IMAGE.read_bytes())
+
+        widget = ImageMarkdown()
+        widget.set_resource_location(tmp_path / "document.md")
+
+        async with _MarkdownApp(widget).run_test() as pilot:
+            await widget.update(f"![Admiral]({TEST_IMAGE.name})")
+            await pilot.pause()
+
+            image_block = widget.query(MarkdownImage).first()
+            assert image_block.support_available is (load_image_support() is not None)
+            if image_block.support_available:
+                for _ in range(5):
+                    if image_block.error is None:
+                        break
+                    await pilot.pause()
+                assert image_block.error is None
+            else:
+                assert image_block.image_widget is None
+                assert image_block.error is not None
+
+    asyncio.run(scenario())
+
+
+def test_missing_local_image_reports_error(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        widget = ImageMarkdown()
+        widget.set_resource_location(tmp_path / "document.md")
+
+        async with _MarkdownApp(widget).run_test() as pilot:
+            await widget.update(f"![Missing]({TEST_IMAGE.name})")
+            await pilot.pause()
+
+            image_block = widget.query(MarkdownImage).first()
+            assert image_block.image_widget is None
+            assert image_block.error is not None
+            assert "not found" in image_block.error.lower()
+
+    asyncio.run(scenario())
+
+
+def test_remote_image_uses_resolver() -> None:
+    async def scenario() -> None:
+        image_bytes = TEST_IMAGE.read_bytes()
+
+        def handler(request: Request) -> Response:
+            return Response(200, content=image_bytes, headers={"content-type": "image/jpeg"})
+
+        transport = MockTransport(handler)
+        resolver = ImageResolver(client_factory=lambda: AsyncClient(transport=transport))
+
+        widget = ImageMarkdown(resolver=resolver)
+        widget.set_resource_location(URL("https://example.com/docs/readme.md"))
+
+        async with _MarkdownApp(widget).run_test() as pilot:
+            await widget.update("![Remote](images/gracehopper.jpg)")
+            await pilot.pause()
+
+            image_block = widget.query(MarkdownImage).first()
+            if image_block.support_available:
+                for _ in range(5):
+                    if image_block.error is None:
+                        break
+                    await pilot.pause()
+                assert image_block.error is None
+                assert image_block.tooltip == "https://example.com/docs/images/gracehopper.jpg"
+            else:
+                assert image_block.image_widget is None
+                assert image_block.error is not None
+
+        await resolver.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_graceful_degradation_when_textual_image_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def scenario() -> None:
+        def no_support() -> None:
+            return None
+
+        no_support.cache_clear = lambda: None  # type: ignore[attr-defined]
+        monkeypatch.setattr("frogmouth.widgets.markdown.load_image_support", no_support)
+        load_image_support.cache_clear()
+
+        widget = ImageMarkdown()
+
+        async with _MarkdownApp(widget).run_test() as pilot:
+            await widget.update("![Alt](missing.png)")
+            await pilot.pause()
+
+            image_block = widget.query(MarkdownImage).first()
+            assert not image_block.support_available
+            assert image_block.image_widget is None
+            assert image_block.error is not None
+            assert "textual-image" in image_block.error.lower()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- add textual-image dependency and a guarded loader for detecting runtime support
- implement an image-aware Markdown widget and resolver to render inline images
- update the viewer, documentation, and tests to cover local and remote images

## Testing
- .venv/bin/ruff check src/ tests/
- .venv/bin/ty check src/ tests/
- .venv/bin/pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc59b527148327bbd8d157555cc7aa